### PR TITLE
Bootstrap 4 fix

### DIFF
--- a/packages/Webkul/Velocity/src/Resources/assets/sass/components/app.scss
+++ b/packages/Webkul/Velocity/src/Resources/assets/sass/components/app.scss
@@ -1046,7 +1046,7 @@
                 }
 
                 .filter-left {
-                    @extend .pull-left;
+                    float: left;
                 }
 
                 .filter-right {


### PR DESCRIPTION
Fixes SASS compile error. Simple fix to work with both not really needed.
SassError: The target selector was not found.
Use "@extend .pull-left !optional" to avoid this error.

**BUGS:**

>Please describe the issue that you solved if its not filed.

>Otherwise please mention issue #id and use comma if your PR
>solves multiple issues.

**For things other than bugs:**

> Describe that thing in very short line, word limit is 200.
> Otherwise use **issue #id** if the issue was filed as **feature** request.